### PR TITLE
Custom documentation pages for MIXS schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,8 @@ gendoc: $(DOCDIR)
 	cp $(SRC)/docs/*md $(DOCDIR) ; \
 	$(RUN) gen-doc ${GEN_DARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH) --template-directory $(TEMPLATEDIR)
 	$(RUN) python $(SRC)/scripts/term_list_generator.py $(TERM_LIST_FILE)
+	mkdir -p $(DOCDIR)/javascripts
+	$(RUN) cp $(SRC)/scripts/javascripts/* $(DOCDIR)/javascripts/
 
 testdoc: gendoc serve
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ SRC = src
 DEST = project
 PYMODEL = $(SRC)/$(SCHEMA_NAME)/datamodel
 DOCDIR = docs
+TEMPLATEDIR = $(SRC)/doc-templates
+TERM_LIST_FILE = $(DOCDIR)/term_list.md
 EXAMPLEDIR = examples
 SHEET_MODULE = personinfo_enums
 SHEET_ID = $(shell ${SHELL} ./utils/get-value.sh google_sheet_id)
@@ -157,7 +159,8 @@ $(DOCDIR):
 
 gendoc: $(DOCDIR)
 	cp $(SRC)/docs/*md $(DOCDIR) ; \
-	$(RUN) gen-doc ${GEN_DARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-doc ${GEN_DARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH) --template-directory $(TEMPLATEDIR)
+	$(RUN) python $(SRC)/scripts/term_list_generator.py $(TERM_LIST_FILE)
 
 testdoc: gendoc serve
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,9 +13,11 @@ plugins:
 nav:
   # - Home: home.md
   - Index: index.md
-  - About: about.md
+  - Full term table: term_list.md
 site_url: https://GenomicsStandardsConsortium.github.io/mixs-6-2-for-merge
 repo_url: https://github.com/GenomicsStandardsConsortium/mixs-6-2-for-merge
+
+docs_dir: docs
 
 # Uncomment this block to enable use of Google Analytics.
 # Replace the property value with your own ID.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,11 @@ theme:
 plugins:
   - search
   - mermaid2
+markdown_extensions:
+  - tables
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascripts/tablesort.js
 nav:
   # - Home: home.md
   - Index: index.md

--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -1,0 +1,123 @@
+# Class: {{ gen.name(element) }}
+
+{%- if header -%}
+{{header}}
+{%- endif -%}
+
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+{% if element.abstract %}
+* __NOTE__: this is an abstract class and should not be instantiated directly
+{% endif %}
+
+URI: {{ gen.uri_link(element) }}
+
+
+{% if diagram_type == "er_diagram" %}
+```{{ gen.mermaid_directive() }}
+{{ gen.mermaid_diagram([element.name]) }}
+```
+{% else %}
+{% include "class_diagram.md.jinja2" %}
+{% endif %}
+
+{% if schemaview.class_parents(element.name) or schemaview.class_children(element.name, mixins=False) %}
+
+## Inheritance
+{{ gen.inheritance_tree(element, mixins=True) }}
+{% else %}
+<!-- no inheritance hierarchy -->
+{% endif %}
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+{% if gen.get_direct_slots(element)|length > 0 %}
+{%- for slot in gen.get_direct_slots(element) -%}
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | direct |
+{% endfor -%}
+{% endif -%}
+{% if gen.get_indirect_slots(element)|length > 0 %}
+{%- for slot in gen.get_indirect_slots(element) -%}
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
+{% endfor -%}
+{% endif %}
+
+{% if schemaview.is_mixin(element.name) %}
+## Mixin Usage
+
+| mixed into | description |
+| --- | --- |
+{% for c in schemaview.class_children(element.name, is_a=False) -%}
+| {{ gen.link(c) }} | {{ schemaview.get_class(c).description|enshorten }} |
+{% endfor %}
+{% endif %}
+
+{% if schemaview.usage_index().get(element.name) %}
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+{% for usage in schemaview.usage_index().get(element.name) -%}
+| {{gen.link(usage.used_by)}} | {{gen.link(usage.slot)}} | {{usage.metaslot}} | {{ gen.link(usage.used) }} |
+{% endfor %}
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+
+{% if schemaview.get_mappings(element.name).items() -%}
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+{% for m, mt in schemaview.get_mappings(element.name).items() -%}
+{% if mt|length > 0 -%}
+| {{ m }} | {{ mt|join(', ') }} |
+{% endif -%}
+{% endfor %}
+
+{% endif -%}
+
+{% if gen.example_object_blobs(element.name) -%}
+## Examples
+{% for name, blob in gen.example_object_blobs(element.name) -%}
+### Example: {{name}}
+
+```yaml
+{{ blob }}
+```
+{% endfor %}
+{% endif %}
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+{{gen.yaml(element)}}
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+{{gen.yaml(element, inferred=True)}}
+```
+</details>
+
+{%- if footer -%}
+{{footer}}
+{%- endif -%}

--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -16,17 +16,6 @@ _{{ element_description_line }}_
 * __NOTE__: this is an abstract class and should not be instantiated directly
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
-
-
-{% if diagram_type == "er_diagram" %}
-```{{ gen.mermaid_directive() }}
-{{ gen.mermaid_diagram([element.name]) }}
-```
-{% else %}
-{% include "class_diagram.md.jinja2" %}
-{% endif %}
-
 {% if schemaview.class_parents(element.name) or schemaview.class_children(element.name, mixins=False) %}
 
 ## Inheritance
@@ -35,7 +24,7 @@ URI: {{ gen.uri_link(element) }}
 <!-- no inheritance hierarchy -->
 {% endif %}
 
-## Slots
+## Terms
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
@@ -50,52 +39,7 @@ URI: {{ gen.uri_link(element) }}
 {% endfor -%}
 {% endif %}
 
-{% if schemaview.is_mixin(element.name) %}
-## Mixin Usage
-
-| mixed into | description |
-| --- | --- |
-{% for c in schemaview.class_children(element.name, is_a=False) -%}
-| {{ gen.link(c) }} | {{ schemaview.get_class(c).description|enshorten }} |
-{% endfor %}
-{% endif %}
-
-{% if schemaview.usage_index().get(element.name) %}
-## Usages
-
-| used by | used in | type | used |
-| ---  | --- | --- | --- |
-{% for usage in schemaview.usage_index().get(element.name) -%}
-| {{gen.link(usage.used_by)}} | {{gen.link(usage.slot)}} | {{usage.metaslot}} | {{ gen.link(usage.used) }} |
-{% endfor %}
-{% endif %}
-
 {% include "common_metadata.md.jinja2" %}
-
-
-{% if schemaview.get_mappings(element.name).items() -%}
-## Mappings
-
-| Mapping Type | Mapped Value |
-| ---  | ---  |
-{% for m, mt in schemaview.get_mappings(element.name).items() -%}
-{% if mt|length > 0 -%}
-| {{ m }} | {{ mt|join(', ') }} |
-{% endif -%}
-{% endfor %}
-
-{% endif -%}
-
-{% if gen.example_object_blobs(element.name) -%}
-## Examples
-{% for name, blob in gen.example_object_blobs(element.name) -%}
-### Example: {{name}}
-
-```yaml
-{{ blob }}
-```
-{% endfor %}
-{% endif %}
 
 
 ## LinkML Source

--- a/src/doc-templates/class_diagram.md.jinja2
+++ b/src/doc-templates/class_diagram.md.jinja2
@@ -1,0 +1,59 @@
+{% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
+        {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+      {% endfor %}
+
+      {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+      {% endfor %}
+      
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+        {% if s.range not in gen.all_type_object_names() %}
+          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% elif schemaview.class_parents(element.name) %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
+        {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+        {% if s.range not in gen.all_type_object_names() %}
+          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% elif schemaview.class_children(element.name)  %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+        {% if s.range not in gen.all_type_object_names() %}
+          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% else %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+        {% if s.range not in gen.all_type_object_names() %}
+          {{ gen.name(element) }} --|> {{ s.range }} : {{ gen.name(s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% endif %}

--- a/src/doc-templates/common_metadata.md.jinja2
+++ b/src/doc-templates/common_metadata.md.jinja2
@@ -1,0 +1,78 @@
+{% if element.aliases %}
+## Aliases
+
+{% for alias in element.aliases %}
+* {{ alias }}
+{%- endfor %}
+{% endif %}
+
+
+{% if element.examples %}
+## Examples
+
+| Value |
+| --- |
+{% for x in element.examples -%}
+| {{ x.value }} |
+{% endfor %}
+{% endif -%}
+
+{% if element.comments -%}
+## Comments
+
+{% for x in element.comments -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
+{% if element.todos -%}
+## TODOs
+
+{% for x in element.todos -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
+{% if element.see_also -%}
+## See Also
+
+{% for x in element.see_also -%}
+* {{ gen.uri_link(x) }}
+{% endfor %}
+{% endif -%}
+
+## Identifier and Mapping Information
+
+{% if element.id_prefixes %}
+### Valid ID Prefixes
+
+Instances of this class *should* have identifiers with one of the following prefixes:
+{% for p in element.id_prefixes %}
+* {{p}}
+{% endfor %}
+
+{% endif %}
+
+
+{% if element.annotations %}
+### Annotations
+
+| property | value |
+| --- | --- |
+{% for a in element.annotations -%}
+{%- if a|string|first != '_' -%}
+| {{ a }} | {{ element.annotations[a].value }} |
+{%- endif -%}
+{% endfor %}
+{% endif %}
+
+{% if element.from_schema or element.imported_from %}
+### Schema Source
+
+{% if element.from_schema %}
+* from schema: {{ element.from_schema }}
+{% endif %}
+{% if element.imported_from %}
+* imported from: {{ element.imported_from }}
+{% endif %}
+{% endif %}

--- a/src/doc-templates/enum.md.jinja2
+++ b/src/doc-templates/enum.md.jinja2
@@ -1,0 +1,44 @@
+# Enum: {{ gen.name(element) }}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+URI: {{ gen.uri_link(element) }}
+
+{% if element.permissible_values -%}
+## Permissible Values
+
+| Value | Description |
+| --- | --- |
+{% for pv in element.permissible_values.values() -%}
+| {{pv.text}} | {{pv.description|enshorten}} |
+{% endfor %}
+{% else %}
+_This is a dynamic enum_
+{% endif %}
+
+{% set slots_for_enum = schemaview.get_slots_by_enum(element.name) %}
+{% if slots_for_enum is defined and slots_for_enum|length > 0 -%}
+## Terms
+
+| Name | Description |
+| ---  | --- |
+{% for s in schemaview.get_slots_by_enum(element.name) -%}
+| {{gen.link(s)}} | {{s.description|enshorten}} |
+{% endfor %}
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+## LinkML Source
+
+<details>
+```yaml
+{{gen.yaml(element)}}
+```
+</details>
+

--- a/src/doc-templates/index.md.jinja2
+++ b/src/doc-templates/index.md.jinja2
@@ -1,0 +1,53 @@
+#  {{ schema.name }}
+
+{{ schema.description }}
+
+URI: <a href={{ schema.id }}>{{ schema.id }}</a>
+
+## Checklists
+
+| Checklist | Description |
+{% for c in schemaview.all_classes().values() -%}
+{%- if c.is_a == "Checklist" -%}
+| --- | --- |
+| {{ gen.link(c) }} | {{ c.description }} |
+{%- endif -%}
+{% endfor %}
+
+## Extensions
+
+| Extension | Description |
+{% for c in schemaview.all_classes().values() -%}
+{%- if c.is_a == "Extension" -%}
+| --- | --- |
+| {{ gen.link(c) }} | {{ c.description }} |
+{%- endif -%}
+{% endfor %}
+
+## Combinations
+
+| Combination | Description |
+{% for c in schemaview.all_classes().values() -%}
+{% if c.mixins and c.is_a -%}
+| --- | --- |
+| {{ gen.link(c) }} | {{ c.description }} |
+{%- endif -%}
+{% endfor %}
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |
+{% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
+| {{gen.link(ss)}} | {{ss.description|enshorten}} |
+{% endfor %}
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+{% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(e)}} | {{e.description|enshorten}} |
+{% endfor %}
+
+

--- a/src/doc-templates/slot.md.jinja2
+++ b/src/doc-templates/slot.md.jinja2
@@ -1,4 +1,4 @@
-# Slot: {{ gen.name(element) }}
+# Term: {{ gen.name(element) }}
 
 {%- if header -%}
 {{header}}
@@ -23,17 +23,6 @@ URI: {{ gen.uri_link(element) }}
 <!-- no inheritance hierarchy -->
 {% endif %}
 
-
-{% if schemaview.is_mixin(element.name) %}
-## Mixin Usage
-
-| mixed into | description | range | domain |
-| --- | --- | --- | --- |
-{% for s in schemaview.slot_children(element.name, is_a=False) -%}
-| {{ gen.link(s) }} | {{ schemaview.get_slot(s).description|enshorten }} | {{ schemaview.get_slot(s).range }} | {{ schemaview.get_classes_by_slot(schemaview.get_slot(s))|join(', ') }} |
-{% endfor %}
-{% endif %}
-
 ## Properties
 
 * Range: {{gen.link(element.range)}}
@@ -51,11 +40,11 @@ URI: {{ gen.uri_link(element) }}
 {% if element.maximum_value is not none %}
 * Maximum Value: {{ element.maximum_value|int }}
 {% endif -%}
+{% if element.structured_pattern.syntax %}
+* Structured pattern: {{ '`' }}{{  element.structured_pattern.syntax }}{{ '`' }}
+{% endif -%}
 {% if element.pattern %}
 * Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
-{% endif -%}
-{% if schemaview.is_mixin(element.name) %}
-* Mixin: {{ element.mixin }}
 {% endif -%}
 
 

--- a/src/doc-templates/slot.md.jinja2
+++ b/src/doc-templates/slot.md.jinja2
@@ -1,0 +1,84 @@
+# Slot: {{ gen.name(element) }}
+
+{%- if header -%}
+{{header}}
+{%- endif -%}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+URI: {{ gen.uri_link(element) }}
+
+
+{% if schemaview.slot_parents(element.name) or schemaview.slot_children(element.name, mixins=False) %}
+
+## Inheritance
+
+{{ gen.inheritance_tree(element, mixins=True) }}
+{% else %}
+<!-- no inheritance hierarchy -->
+{% endif %}
+
+
+{% if schemaview.is_mixin(element.name) %}
+## Mixin Usage
+
+| mixed into | description | range | domain |
+| --- | --- | --- | --- |
+{% for s in schemaview.slot_children(element.name, is_a=False) -%}
+| {{ gen.link(s) }} | {{ schemaview.get_slot(s).description|enshorten }} | {{ schemaview.get_slot(s).range }} | {{ schemaview.get_classes_by_slot(schemaview.get_slot(s))|join(', ') }} |
+{% endfor %}
+{% endif %}
+
+## Properties
+
+* Range: {{gen.link(element.range)}}
+{% if element.multivalued %}
+* Multivalued: {{ element.multivalued }}
+{% endif -%}
+{% if element.required %}
+* Required: {{ element.required }}
+{% elif element.recommended %}
+* Recommended: {{ element.recommended }}
+{% endif -%}
+{% if element.minimum_value is not none %}
+* Minimum Value: {{ element.minimum_value|int }}
+{% endif -%}
+{% if element.maximum_value is not none %}
+* Maximum Value: {{ element.maximum_value|int }}
+{% endif -%}
+{% if element.pattern %}
+* Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
+{% endif -%}
+{% if schemaview.is_mixin(element.name) %}
+* Mixin: {{ element.mixin }}
+{% endif -%}
+
+
+{% if schemaview.usage_index().get(element.name) %}
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+{% for usage in schemaview.usage_index().get(element.name) -%}
+| {{gen.link(usage.used_by)}} | {{gen.link(usage.slot)}} | {{usage.metaslot}} | {{ gen.link(usage.used) }} |
+{% endfor %}
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+## LinkML Source
+
+<details>
+```yaml
+{{ gen.yaml(element) }}
+```
+</details>
+
+{%- if footer -%}
+{{footer}}
+{%- endif -%}

--- a/src/scripts/javascripts/tablesort.js
+++ b/src/scripts/javascripts/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function () {
+  var tables = document.querySelectorAll("article table:not([class])");
+  tables.forEach(function (table) {
+    new Tablesort(table);
+  });
+});

--- a/src/scripts/term_list_generator.py
+++ b/src/scripts/term_list_generator.py
@@ -1,0 +1,54 @@
+import sys
+import logging
+from typing import Iterator
+from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.linkml_model.meta import SlotDefinition
+
+logging.basicConfig(
+    filename="term_list_generator.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def all_slot_objects(sv: SchemaView) -> Iterator[SlotDefinition]:
+    """
+    all slot objects in schema
+
+    Ensures rank is non-null
+    :return: iterator
+    """
+    elts = sv.all_slots().values()
+    for e in elts:
+        yield e
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        logger.error(
+            "Usage: `poetry run python src/scripts/term_list_generator.py <output-file.md>`"
+        )
+        sys.exit(1)
+
+    output_file = sys.argv[1]
+
+    sv = SchemaView("src/mixs_6_2_for_merge/schema/mixs_6_2_for_merge.yaml")
+    terms = list(all_slot_objects(sv))
+
+    try:
+        with open(output_file, "w") as md_file:
+            md_file.write("# List of all terms in MIXS schema\n\n")
+
+            md_file.write("| Name | Description |\n")
+            md_file.write("| --- | --- |\n")
+
+            for t in terms:
+                name = t.name
+                description = t.description
+                link = f"[{name}]({t.from_schema}/{t.slot_uri.split(':')[-1]})"
+                md_file.write(f"| {link} | {description} |\n")
+
+        logger.info(f"Term list table has been written to '{output_file}'.")
+    except Exception as e:
+        logger.error(f"Error writing to '{output_file}': {str(e)}")


### PR DESCRIPTION
Tasks accomplished in this PR:

- [x] Add custom jinja templates for MIXS schema documentation pages
- [x] Ad hoc script for generating table of all terms in schema with link out from index page
- [x] Necessary makefile rule modifications
- [x] Markdown/HTML table sorting